### PR TITLE
Disable default Rubocop styles

### DIFF
--- a/.ruby-style.yml
+++ b/.ruby-style.yml
@@ -1,10 +1,16 @@
 AllCops:
+  DisabledByDefault: true
   Exclude:
     - "vendor/**/*"
     - "db/schema.rb"
   UseCache: false
 
 ######### Ruby #########
+
+Style/StringLiterals:
+  Description: 'Checks if uses of quotes match the configured preference.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#consistent-string-literals'
+  Enabled: false
 
 Style/FileName:
   Description: Use snake_case for source file names.


### PR DESCRIPTION
This PR will add a config that prevents Hound from being too noisy. Only the configs specified in the lint config file should be seen as a violation.

https://github.com/thoughtbot/hound/issues/1049

cc @kenliu 